### PR TITLE
[lld][InstrProf] Do not use cstring offset hashes in function order for compression

### DIFF
--- a/lld/MachO/BPSectionOrderer.cpp
+++ b/lld/MachO/BPSectionOrderer.cpp
@@ -53,11 +53,8 @@ getRelocHash(const Reloc &reloc,
     kind = ("Section " + Twine(static_cast<uint8_t>(isec->kind()))).str();
   if (auto *sym = reloc.referent.dyn_cast<Symbol *>()) {
     kind += (" Symbol " + Twine(static_cast<uint8_t>(sym->kind()))).str();
-    if (auto *d = dyn_cast<Defined>(sym)) {
-      if (isa_and_nonnull<CStringInputSection>(isec))
-        return getRelocHash(kind, 0, isec->getOffset(d->value), reloc.addend);
+    if (auto *d = dyn_cast<Defined>(sym))
       return getRelocHash(kind, sectionIdx.value_or(0), d->value, reloc.addend);
-    }
   }
   return getRelocHash(kind, sectionIdx.value_or(0), 0, reloc.addend);
 }


### PR DESCRIPTION
Do not use cstring offset hashes in function order for compression

Using the hashes of cstring offset turned to have very minimal impact on the compressed size of large iOS apps. The patch removes that code, thus the cstring symbols will be treated the same way as other defined symbols in terms of hashes calculation.